### PR TITLE
Allow for preprocessing command in JSON

### DIFF
--- a/src/main/java/edu/yale/library/jpegs2pdf/JpegPdfConcatImpl.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/JpegPdfConcatImpl.java
@@ -365,6 +365,7 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 					in,
 					processingInputFile.toPath(),
 					StandardCopyOption.REPLACE_EXISTING);
+			in.close();
 			processingOutputFile = File.createTempFile("pdfPageConverted", "img");
 			processingOutputFile.delete();
 			Process process;
@@ -383,7 +384,7 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 			if (exitCode == 0 && processingOutputFile.exists()) {
 				in = new FileInputStream(processingOutputFile);
 			} else {
-				System.out.println("Preprocessing failed: " + cmd);
+				throw new IOException("Preprocessing failed: " + cmd);
 			}
 		}
 		try {

--- a/src/main/java/edu/yale/library/jpegs2pdf/JpegPdfConcatImpl.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/JpegPdfConcatImpl.java
@@ -343,11 +343,11 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 			h = w / imageAspect;
 			y = (PDRectangle.LETTER.getHeight() - yPos - h) / 2;
 		}
-		if ( imageAspect > 1 ) {
-			bimg = resizeImage(bimg, 2000, (int)(2000.0 / imageAspect));
-		} else {
-			bimg = resizeImage(bimg, (int)(2000.0 * imageAspect), 2000);
-		}
+//		if ( imageAspect > 1 ) {
+//			bimg = resizeImage(bimg, 2000, (int)(2000.0 / imageAspect));
+//		} else {
+//			bimg = resizeImage(bimg, (int)(2000.0 * imageAspect), 2000);
+//		}
 		PDImageXObject pdImageXObject = JPEGFactory.createFromImage(document, bimg);
 		COSDictionary cosDictionary = beginMarkedConent(contentStream, COSName.IMAGE);
 		contentStream.drawImage(pdImageXObject, x, y, w, h);
@@ -366,7 +366,7 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 					processingInputFile.toPath(),
 					StandardCopyOption.REPLACE_EXISTING);
 			in.close();
-			processingOutputFile = File.createTempFile("pdfPageConverted", "img");
+			processingOutputFile = File.createTempFile("pdfPageConverted", ".jpg");
 			processingOutputFile.delete();
 			Process process;
 			String cmd = String.format(imageProcessingCommand, processingInputFile.getAbsolutePath(), processingOutputFile.getAbsolutePath());

--- a/src/main/java/edu/yale/library/jpegs2pdf/JpegPdfConcatImpl.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/JpegPdfConcatImpl.java
@@ -7,10 +7,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -56,17 +59,19 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 	private PDStructureElement currentPart;
 	private PDStructureElement currentSection;
 	private int mcid = 1;
+	private String imageProcessingCommand;
 	
 	private PDDocument document;
 	
 	
-	public void generatePdf(String header, String documentTitle, List<Property> documentProperties, List<Property> documentAddressLines, List<JpegPdfPage> jpegPdfPages, File destinationFile) 
+	public void generatePdf(String header, String documentTitle, List<Property> documentProperties, List<Property> documentAddressLines, List<JpegPdfPage> jpegPdfPages, File destinationFile, String imageProcessingCommand)
 			throws IOException {
 		this.header = header;
 		this.documentTitle = documentTitle;
 		this.properties = documentProperties;
 		this.addressLines = documentAddressLines;
 		this.pages = jpegPdfPages;
+		this.imageProcessingCommand = imageProcessingCommand;
 		
 		long start = System.currentTimeMillis();		
 		createDocument();
@@ -321,12 +326,7 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 	private void drawImageOnPage(JpegPdfPage jpegPdfPage, PDPage page, PDPageContentStream contentStream, float yPos,
 			float margin) throws IOException {
 		InputStream in = jpegPdfPage.createInputStream();
-		BufferedImage bimg = null;
-		try {			
-			bimg = ImageIO.read(in);
-		} finally {
-			in.close();
-		}
+		BufferedImage bimg = getBufferedImage(in);
 		float width = bimg.getWidth();
 		float height = bimg.getHeight();
 		float pageAspect = PDRectangle.LETTER.getWidth() / (PDRectangle.LETTER.getHeight() - yPos);
@@ -353,6 +353,51 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 		contentStream.drawImage(pdImageXObject, x, y, w, h);
 		contentStream.endMarkedContent();
 		addImageToStructure( page, currentSection, pdImageXObject, jpegPdfPage.getCaption(), cosDictionary);
+	}
+
+	private BufferedImage getBufferedImage(InputStream in) throws IOException {
+		BufferedImage bimg;
+		File processingInputFile = null;
+		File processingOutputFile = null;
+		if (imageProcessingCommand != null) {
+			processingInputFile = File.createTempFile("pdfPageOriginal", "img");
+			java.nio.file.Files.copy(
+					in,
+					processingInputFile.toPath(),
+					StandardCopyOption.REPLACE_EXISTING);
+			processingOutputFile = File.createTempFile("pdfPageConverted", "img");
+			processingOutputFile.delete();
+			Process process;
+			String cmd = String.format(imageProcessingCommand, processingInputFile.getAbsolutePath(), processingOutputFile.getAbsolutePath());
+			process = Runtime.getRuntime()
+					.exec(cmd);
+			StreamGobbler streamGobbler =
+					new StreamGobbler(process.getInputStream(), System.out::println);
+			Executors.newSingleThreadExecutor().submit(streamGobbler);
+			int exitCode = 0;
+			try {
+				exitCode = process.waitFor();
+			} catch (InterruptedException e) {
+				throw new IOException(e);
+			}
+			if (exitCode == 0 && processingOutputFile.exists()) {
+				in = new FileInputStream(processingOutputFile);
+			} else {
+				System.out.println("Preprocessing failed: " + cmd);
+			}
+		}
+		try {
+			bimg = ImageIO.read(in);
+		} finally {
+			in.close();
+		}
+		if (processingInputFile != null) {
+			processingInputFile.delete();
+		}
+		if (processingOutputFile != null) {
+			processingOutputFile.delete();
+		}
+		return bimg;
 	}
 
 	private BufferedImage resizeImage( BufferedImage image, int width, int height ) {
@@ -418,6 +463,21 @@ public class JpegPdfConcatImpl implements JpegPdfConcat {
 		
 	}
 
+	private static class StreamGobbler implements Runnable {
+		private InputStream inputStream;
+		private Consumer<String> consumer;
+
+		public StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
+			this.inputStream = inputStream;
+			this.consumer = consumer;
+		}
+
+		@Override
+		public void run() {
+			new BufferedReader(new InputStreamReader(inputStream)).lines()
+					.forEach(consumer);
+		}
+	}
 	
 
 }

--- a/src/main/java/edu/yale/library/jpegs2pdf/model/JpegPdfPage.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/model/JpegPdfPage.java
@@ -16,7 +16,6 @@ public class JpegPdfPage {
 	public InputStream createInputStream() throws IOException {
 		String filename = getJpegSource();
 		if (filename.startsWith("http://") || filename.startsWith("https://")) {
-			File destination = File.createTempFile("pdf-gen", ".jpg");
 			URL website = new URL(filename);
 			return website.openStream();
 		} else {

--- a/src/main/java/edu/yale/library/jpegs2pdf/model/PdfDocument.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/model/PdfDocument.java
@@ -1,5 +1,0 @@
-package edu.yale.library.jpegs2pdf.model;
-
-public class PdfDocument {
-
-}

--- a/src/main/java/edu/yale/library/jpegs2pdf/processor/JpegPdfConcat.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/processor/JpegPdfConcat.java
@@ -9,6 +9,6 @@ import edu.yale.library.jpegs2pdf.model.JpegPdfPage;
 import edu.yale.library.jpegs2pdf.model.Property;
 
 public interface JpegPdfConcat {
-	void generatePdf(String header, String documentTitle,  List<Property> documentProperties, List<Property>  documentAddressLines, List<JpegPdfPage> jpegPdfPages, File destinationFile) throws IOException;
+	void generatePdf(String header, String documentTitle,  List<Property> documentProperties, List<Property>  documentAddressLines, List<JpegPdfPage> jpegPdfPages, File destinationFile, String imageProcessingCommand) throws IOException;
 		
 }

--- a/src/main/java/edu/yale/library/jpegs2pdf/processor/JsonToPdfProcessorImpl.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/processor/JsonToPdfProcessorImpl.java
@@ -53,7 +53,8 @@ public class JsonToPdfProcessorImpl implements PdfProcessor {
 		}
 		
 		String documentTitle = document.getString("title", "No Title");
-		String header = document.getString("header", "Yale University Library Digital Collections") ;
+		String header = document.getString("header", "Yale University Library Digital Collections");
+		String imageProcessingComment = document.getString("imageProcessingCommand", null);
 
 		List<JpegPdfPage> jpegPdfPages = new ArrayList<JpegPdfPage>();
 		for (JsonValue pageValue : pages) {
@@ -67,7 +68,7 @@ public class JsonToPdfProcessorImpl implements PdfProcessor {
 			jpegPdfPage.setProperties(pageProperties);
 			jpegPdfPages.add(jpegPdfPage);
 		}
-		jpegPdfConcat.generatePdf(header, documentTitle, documentProperties, documentAddressLines, jpegPdfPages, new File(destinationPdfFilepath));
+		jpegPdfConcat.generatePdf(header, documentTitle, documentProperties, documentAddressLines, jpegPdfPages, new File(destinationPdfFilepath), imageProcessingComment);
 	}
 	
 


### PR DESCRIPTION
This PR adds the ability to add a preprocessing command to the JSON file the app uses to generate the PDF.
If a preprocessing command it provided, the image on each page will be run through the preprocessing command before being used for the PDF.

If the image source is http, a temp file will be created before passing off to the command.

Example:
`"imageProcessingCommand": "vips jpegsave %s %s" `
in the JSON will cause the images to be run with `vips jpegsave <source image>  <destination image>` and the destination image is used if it was successfully created and the command has a 0 exit code.

The destination image temp file has a .jpg extension to help with ImageMagick.
The image resize code has been commented out.  It was there to resample images with incompatible color spaces.  If images have a incompatible color space, they can be fixed with the processing command.