### PR TITLE
Retry reprocessing command on failure, exit with 1 if exception

### DIFF
--- a/src/main/java/edu/yale/library/jpegs2pdf/App.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/App.java
@@ -12,7 +12,12 @@ import edu.yale.library.jpegs2pdf.processor.PdfProcessor;
 public class App {
 
 	public static void main(String[] args) throws Exception {
-		run(args);
+		try {
+			run(args);
+		} catch (Exception e) {
+			e.printStackTrace();
+			System.exit(1);
+		}
 		System.exit(0);
 	}
 


### PR DESCRIPTION
Retry image processing external command if it fails, up to 5 times.
Adds System.exit on exception so app exits even if some non-daemon threads are still running.