### PR TITLE
Update font selection to choose on each snippet, and put in boxes

### DIFF
--- a/sample-json/32259802.json
+++ b/sample-json/32259802.json
@@ -1,6 +1,6 @@
 {
   "displayCoverPage": true,
-  "title": "Shams al-maʻārif wa-laṭāʼif al-ʻawārif, [17--?]<br/>شمس المعارف ولطائف العوارف، [17--?]",
+  "title": "◌ٔShams al-maʻārif wa-laṭāʼif al-ʻawārif, [17--?], شمس المعارف ول◌ٔطائف العوارف، [17--?]",
   "header": "Yale University Library Digital Collections",
   "pages": [
     {
@@ -20,7 +20,7 @@
   "properties": [
     {
       "name": "Title:",
-      "value": "Shams al-maʻārif wa-laṭāʼif al-ʻawārif, [17--?]<br/>شمس المعارف ولطائف العوارف، [17--?]"
+      "value": "Shams al-maʻārif wa-laṭāʼif al-ʻawārif, [17--?], شمس المعارف ولطائف العوارف، [17--?]"
     },
     {
       "name": "Date:",

--- a/src/main/java/edu/yale/library/jpegs2pdf/processor/JsonToPdfProcessorImpl.java
+++ b/src/main/java/edu/yale/library/jpegs2pdf/processor/JsonToPdfProcessorImpl.java
@@ -1,28 +1,21 @@
 package edu.yale.library.jpegs2pdf.processor;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import edu.yale.library.jpegs2pdf.model.JpegPdfPage;
+import edu.yale.library.jpegs2pdf.model.Property;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.json.JsonValue;
-
-import edu.yale.library.jpegs2pdf.model.JpegPdfPage;
-import edu.yale.library.jpegs2pdf.model.Property;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JsonToPdfProcessorImpl implements PdfProcessor {
 	private JsonReader jsonReader;
 	private JpegPdfConcat jpegPdfConcat;
-	
+
 
 	public JsonToPdfProcessorImpl(JsonReader jsonReader, JpegPdfConcat jpegPdfConcat) {
 		this.jsonReader = jsonReader;
@@ -33,14 +26,14 @@ public class JsonToPdfProcessorImpl implements PdfProcessor {
 
 	@Override
 	public void generatePdf( String destinationPdfFilepath) throws IOException {
-		
+
 		JsonObject document = jsonReader.readObject();
 		jsonReader.close();
-		
-		
+
+
 		JsonArray pages = document.getJsonArray("pages");
 		List<Property> documentProperties = null;
-		
+
 		if ( document.containsKey("properties") ) {
 			JsonArray properties = document.getJsonArray("properties");
 			documentProperties = propertyListFromJsonArray(properties);
@@ -51,7 +44,7 @@ public class JsonToPdfProcessorImpl implements PdfProcessor {
 			JsonArray addressLines = document.getJsonArray("addressLines");
 			documentAddressLines = propertyListFromJsonArray(addressLines);
 		}
-		
+
 		String documentTitle = document.getString("title", "No Title");
 		String header = document.getString("header", "Yale University Library Digital Collections");
 		String imageProcessingComment = document.getString("imageProcessingCommand", null);
@@ -70,7 +63,7 @@ public class JsonToPdfProcessorImpl implements PdfProcessor {
 		}
 		jpegPdfConcat.generatePdf(header, documentTitle, documentProperties, documentAddressLines, jpegPdfPages, new File(destinationPdfFilepath), imageProcessingComment);
 	}
-	
+
 
 	private static List<Property> propertyListFromJsonArray(JsonArray properties) throws IOException {
 		List<Property> ret = new ArrayList<Property>();

--- a/src/test/java/edu/yale/library/jpegs2pdf/JpegPdfConcatTest.java
+++ b/src/test/java/edu/yale/library/jpegs2pdf/JpegPdfConcatTest.java
@@ -3,11 +3,16 @@ package edu.yale.library.jpegs2pdf;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
+
+import java.io.IOException;
 
 /**
  * Unit test for simple App.
  */
-public class JpegPdfConcatTest 
+public class JpegPdfConcatTest
     extends TestCase
 {
     /**
@@ -34,5 +39,21 @@ public class JpegPdfConcatTest
     public void testApp()
     {
         assertTrue( true );
+    }
+
+    public void testFontFound() throws IOException {
+        String text = "شمس المعارف ول◌ٔطائف العوارف،";
+        String textWithBox = "شمس المعارف ول◌□طائف العوارف،";
+        PDDocument document = new PDDocument();
+        PDFont arabicRegFont = PDType0Font.load(document, this.getClass().getResourceAsStream("/NotoNaskhArabic-Regular.ttf"));
+        PDFont latinRegFont = PDType0Font.load(document, this.getClass().getResourceAsStream("/arialunicodems.ttf"));
+        JpegPdfConcatImpl jpegPdfConcat = new JpegPdfConcatImpl();
+
+        JpegPdfConcatImpl.FontAndText fontAndText = jpegPdfConcat.pickFontAndText(text, new PDFont[] {latinRegFont, arabicRegFont});
+        assertTrue("Text is not changed if font is available", fontAndText.getText().equals(text));
+
+        fontAndText = jpegPdfConcat.pickFontAndText(text, new PDFont[] {latinRegFont});
+        assertTrue("Text is changed if font is not found", !fontAndText.getText().equals(text));
+        assertTrue("Text has the box for replacement", fontAndText.getText().equals(textWithBox));
     }
 }


### PR DESCRIPTION
Fonts are chosen by each snippet of text at break points (white space).
If a font cannot be found from the font array, alter the text so that un-renderable characters are replaces with a box (□)